### PR TITLE
Add application error handler

### DIFF
--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -1,0 +1,175 @@
+<?php
+declare(strict_types=1);
+
+namespace Newtron\Core\Error;
+
+use Newtron\Core\Http\Response;
+use Newtron\Core\Http\Status;
+use Newtron\Core\Quark\Quark;
+
+class ErrorHandler {
+  private Logger $logger;
+  private bool $debug;
+  private $errorPages = [];
+
+  public function __construct(Logger $logger, bool $debug = false) {
+    $this->logger = $logger;
+    $this->debug = $debug;
+
+    set_error_handler([$this, 'handleError']);
+    set_exception_handler([$this, 'handleException']);
+    register_shutdown_function([$this, 'handleFatalError']);
+  }
+
+  public function setErrorPage(Status|int $statusCode, string $template): void {
+    $this->errorPages[$statusCode] = $template;
+  }
+
+  public function handleError(int $severity, string $message, string $filename, int $lineno): bool {
+    if (!(error_reporting() & $severity)) {
+      return false;
+    }
+
+    $context = [
+      'severity' => $severity,
+      'file' => $filename,
+      'line' => $lineno,
+      'trace' => debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)
+    ];
+
+    $this->logger->error("PHP Error: $message", $context);
+
+    throw new \ErrorException($message, 0, $severity, $filename, $lineno);
+  }
+
+  public function handleException(\Throwable $exception): void {
+    $this->cleanOutputBuffers();
+
+
+    try {
+      if ($exception instanceof HttpException) {
+        $this->handleHttpException($exception);
+      } else {
+        $this->logException($exception);
+        $this->handleGenericException($exception);
+      }
+    } catch (\Throwable $renderException) {
+      $this->logger->critical('Error rendering error page', [
+        'original_exception' => $exception->getMessage(),
+        'render_exception' => $renderException->getMessage()
+      ]);
+
+      $this->showBasicErrorPage($exception);
+    }
+  }
+
+  public function handleFatalError(): void {
+    $error = error_get_last();
+
+    if ($error && in_array($error['type'], [E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_PARSE])) {
+      $this->cleanOutputBuffers();
+
+      $this->logger->critical('Fatal Error', [
+        'message' => $error['message'],
+        'file' => $error['file'],
+        'line' => $error['line'],
+        'type' => $error['type']
+      ]);
+
+      if ($this->debug) {
+        $this->showDebugFatalError($error);
+      } else {
+        $this->showError(500);
+      }
+    }
+  }
+
+  private function cleanOutputBuffers(): void {
+    while (ob_get_level()) {
+      ob_end_clean();
+    }
+  }
+
+  private function logException(\Throwable $exception): void {
+    $context = [
+      'exception' => get_class($exception),
+      'message' => $exception->getMessage(),
+      'file' => $exception->getFile(),
+      'line' => $exception->getLine(),
+      'code' => $exception->getCode(),
+      'trace' => $exception->getTraceAsString(),
+      'url' => $_SERVER['REQUEST_URI'] ?? 'N/A',
+      'method' => $_SERVER['REQUEST_METHOD'] ?? 'N/A',
+      'user_agent' => $_SERVER['HTTP_USER_AGENT'] ?? 'N/A'
+    ];
+
+    $this->logger->error('Uncaught Exception', $context);
+  }
+
+  private function handleHttpException(HttpException $exception): void {
+    if ($this->debug) {
+      $this->showDebugError($exception);
+    } else {
+      $this->showError($exception->getStatusCode());
+    }
+  }
+
+  private function handleGenericException(\Throwable $exception): void {
+    if ($this->debug) {
+      $this->showDebugError($exception);
+    } else {
+      $this->showError(Status::INTERNAL_ERROR);
+    }
+  }
+
+  private function showDebugError(\Throwable $exception): void {
+    $trace = $exception->getTrace();
+
+    ob_start();
+    include dirname(__FILE__) . '/_debug-error.php';
+    $page = ob_get_clean();
+
+    Response::create($page, Status::INTERNAL_ERROR)->send();
+  }
+
+  private function showDebugFatalError(array $error): void {
+    ob_start();
+    include dirname(__FILE__) . '/_debug-fatal.php';
+    $page = ob_get_clean();
+
+    Response::create($page, Status::INTERNAL_ERROR)->send();
+  }
+
+  private function showError(Status|int $statusCode): void {
+    $message = 'An error occurred';
+    if ($statusCode instanceof Status) {
+      $message = $statusCode->getText();
+      $statusCode = $statusCode->value;
+    } else {
+      $code = Status::tryFrom($statusCode);
+      if ($code) {
+        $message = $code->getText();
+      }
+    }
+
+    $page = null;
+    if (isset($this->errorPages[$statusCode])) {
+      try {
+        $page = Quark::render($this->errorPages[$statusCode]);
+      } catch (\Throwable $e) {}
+    }
+
+    if ($page === null) {
+      ob_start();
+      include dirname(__FILE__) . '/_default-error.php';
+      $page = ob_get_clean();
+    }
+
+    Response::create($page, $statusCode)->send();
+  }
+
+  private function showBasicErrorPage(\Throwable $exception): void {
+    http_response_code(500);
+    echo "An error occurred. Please try again later.";
+  }
+}

--- a/src/Error/HttpException.php
+++ b/src/Error/HttpException.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Newtron\Core\Error;
+
+use Newtron\Core\Http\Status;
+
+class HttpException extends \Exception {
+  protected int $statusCode;
+
+  public function __construct(Status|int $statusCode, $message = "", $code = 0, \Exception $previous = null) {
+    parent::__construct($message, $code, $previous);
+    if ($statusCode instanceof Status) {
+      $statusCode = $statusCode->value;
+    }
+    $this->statusCode = $statusCode;
+  }
+
+  public function getStatusCode(): int {
+    return $this->statusCode;
+  }
+}

--- a/src/Error/Logger.php
+++ b/src/Error/Logger.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace Newtron\Core\Error;
+
+class Logger {
+  const DEBUG = 'debug';
+  const INFO = 'info';
+  const WARNING = 'warning';
+  const ERROR = 'error';
+  const CRITICAL = 'critical';
+
+  private string $logPath;
+  private int $maxFileSize;
+  private int $maxFiles;
+
+  public function __construct(string $logPath = 'logs', $maxFileSize = 10485760, $maxFiles = 5) {
+    $this->logPath = rtrim($logPath, '/');
+    $this->maxFileSize = $maxFileSize;
+    $this->maxFiles = $maxFiles;
+
+    if (!is_dir($this->logPath)) {
+      mkdir($this->logPath, 0755, true);
+    }
+  }
+
+  public function log(string $level, string $message, array $context = []): void {
+    $timestamp = date('Y-m-d H:i:s');
+    $contextStr = !empty($context) ? json_encode($context, JSON_UNESCAPED_SLASHES): '';
+
+    $logEntry = sprintf(
+      "[%s] %s: %s %s\n",
+      $timestamp,
+      strtoupper($level),
+      $message,
+      $contextStr
+    );
+
+    $logFile = $this->logPath . '/' . date('Y-m-d') . '.log';
+
+    $this->rotateLogIfNeeded($logFile);
+
+    file_put_contents($logFile, $logEntry, FILE_APPEND | LOCK_EX);
+  }
+
+  public function debug(string $message, array $context = []): void {
+    $this->log(self::DEBUG, $message, $context);
+  }
+
+  public function info(string $message, array $context = []): void {
+    $this->log(self::INFO, $message, $context);
+  }
+
+  public function warning(string $message, array $context = []): void {
+    $this->log(self::WARNING, $message, $context);
+  }
+
+  public function error(string $message, array $context = []): void {
+    $this->log(self::ERROR, $message, $context);
+  }
+
+  public function critical(string $message, array $context = []): void {
+    $this->log(self::CRITICAL, $message, $context);
+  }
+
+  private function rotateLogIfNeeded(string $logFile): void {
+    if (!file_exists($logFile) || filesize($logFile) < $this->maxFileSize) {
+      return;
+    }
+
+    for ($i = $this->maxFiles - 1; $i >= 1; $i--) {
+      $oldFile = $logFile . '.' . $i;
+      $newFile = $logFile . '.' . ($i + 1);
+
+      if (file_exists($oldFile)) {
+        unlink($oldFile);
+      } else {
+        rename($oldFile, $newFile);
+      }
+    }
+
+    rename($logFile, $logFile . '.1');
+  }
+}

--- a/src/Error/_debug-error.php
+++ b/src/Error/_debug-error.php
@@ -1,0 +1,61 @@
+<?php
+namespace Newtron\Core\Error;
+/** @var \Throwable $exception */
+/** @var array $trace */
+?>
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Error - <?= htmlspecialchars(get_class($exception)) ?></title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 0; padding: 20px; background: #15171b; }
+      .error-container { background: #f8f8f2; color: #15171b; padding: 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+      .error-header { color: #d32f2f; border-bottom: 2px solid #d32f2f; padding-bottom: 15px; margin-bottom: 20px; }
+      .error-message { font-size: 18px; margin-bottom: 20px; }
+      .error-location { background: #414558; color: #f8f8f2; padding: 10px; border-left: 4px solid #05b6e7; margin-bottom: 20px; }
+      .stack-trace { background: #21222c; color: #f8f8f2; padding: 15px; border-radius: 4px; overflow-x: auto; }
+      .trace-item { margin-bottom: 10px; }
+      .trace-file { color: #05b6e7; }
+      .trace-line { color: #fd971f; }
+      .trace-function { color: #a6e22e; }
+      .request-info { margin-top: 20px; padding: 15px; background: #cdf0fa; border-radius: 4px; }
+    </style>
+  </head>
+  <body>
+    <div class="error-container">
+      <h1 class="error-header"><?= htmlspecialchars(get_class($exception)) ?></h1>
+      
+      <div class="error-message">
+        <strong><?= htmlspecialchars($exception->getMessage()) ?></strong>
+      </div>
+      
+      <div class="error-location">
+        <strong>File:</strong> <?= htmlspecialchars($exception->getFile()) ?><br>
+        <strong>Line:</strong> <?= $exception->getLine() ?>
+      </div>
+      
+      <h3>Stack Trace:</h3>
+      <div class="stack-trace">
+        <?php foreach ($trace as $i => $item): ?>
+          <div class="trace-item">
+            #<?= $i ?> 
+            <?php if (isset($item['file'])): ?>
+              <span class="trace-file"><?= htmlspecialchars($item['file']) ?></span>
+              <span class="trace-line">(<?= $item['line'] ?>)</span>:
+            <?php endif; ?>
+            <span class="trace-function">
+              <?= isset($item['class']) ? htmlspecialchars($item['class'] . $item['type']) : '' ?>
+              <?= htmlspecialchars($item['function']) ?>()
+            </span>
+          </div>
+        <?php endforeach; ?>
+      </div>
+      
+      <div class="request-info">
+        <h3>Request Information:</h3>
+        <strong>URL:</strong> <?= htmlspecialchars($_SERVER['REQUEST_URI'] ?? 'N/A') ?><br>
+        <strong>Method:</strong> <?= htmlspecialchars($_SERVER['REQUEST_METHOD'] ?? 'N/A') ?><br>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/Error/_debug-fatal.php
+++ b/src/Error/_debug-fatal.php
@@ -1,0 +1,27 @@
+<?php
+namespace Newtron\Core\Error;
+/** @var array $error */
+?>
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fatal Error</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 0; padding: 20px; background: #15171b; }
+      .error-container { background: #f8f8f2; color: #15171b; padding: 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+      .error-header { color: #d32f2f; border-bottom: 2px solid #d32f2f; padding-bottom: 15px; margin-bottom: 20px; }
+      .error-message { font-size: 18px; margin-bottom: 20px; }
+      .error-location { background: #f8f8f2; padding: 10px; border-left: 4px solid #d32f2f; }
+    </style>
+  </head>
+  <body>
+    <div class="error-container">
+      <h1 class="error-header">Fatal Error</h1>
+      <div class="error-message"><?= htmlspecialchars($error['message']) ?></div>
+      <div class="error-location">
+        <strong>File:</strong> <?= htmlspecialchars($error['file']) ?><br>
+        <strong>Line:</strong> <?= $error['line'] ?>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/Error/_default-error.php
+++ b/src/Error/_default-error.php
@@ -1,0 +1,26 @@
+<?php
+namespace Newtron\Core\Error;
+/** @var int $statusCode */
+/** @var string $message */
+?>
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><?= $statusCode ?> - <?= $message ?></title>
+    <style>
+      body { font-family: Arial, sans-serif; text-align: center; padding: 50px; background: #f8f8f2; }
+      .error-container { display: inline-block; text-align: left; }
+      h1 { color: #15171b; }
+      p { color: #626784; margin: 20px 0; }
+      a { color: #05b6e7; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+    </style>
+  </head>
+  <body>
+    <div class="error-container">
+      <h1><?= $statusCode ?> - <?= $message ?></h1>
+      <p>Sorry, something went wrong. Please try again later.</p>
+      <p><a href="/">← Back to Home</a></p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Handle errors with rendered error pages
- Default Quark templates for error pages
- Can define custom templates to render for different errors
- Supports `debug` config option to display error trace and info