### PR TITLE
Release 0.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "newtron/core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "library",
   "description": "Core framework package for Newtron",
   "homepage": "https://github.com/newtron-framework/core",

--- a/src/Quark/QuarkEngine.php
+++ b/src/Quark/QuarkEngine.php
@@ -208,6 +208,39 @@ class QuarkEngine {
   }
 
   /**
+   * Smart accessor for arrays, objects, and ArrayAccess
+   *
+   * @param  mixed  $value The value to access on
+   * @param  string $key   The member to access
+   */
+  public function access(mixed $value, string $key): mixed {
+    if ($value === null) {
+      return null;
+    }
+
+    if (is_array($value) || $value instanceof \ArrayAccess) {
+      return $value[$key] ?? null;
+    }
+
+    if (is_object($value)) {
+      if (property_exists($value, $key)) {
+        return $value->$key;
+      }
+
+      $getter = 'get' . ucfirst($key);
+      if (method_exists($value, $getter)) {
+        return $value->$getter();
+      }
+
+      if (method_exists($value, '__get')) {
+        return $value->__get($key);
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Apply a filter to a value
    *
    * @param  string $name  The filter name

--- a/tests/Mocks/Quark/NestedObject.php
+++ b/tests/Mocks/Quark/NestedObject.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Mocks\Quark;
+
+class NestedObject {
+  public string $property = 'Nested Property';
+
+  public function method(): string {
+    return 'Nested Method';
+  }
+}

--- a/tests/Mocks/Quark/SimpleObject.php
+++ b/tests/Mocks/Quark/SimpleObject.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Mocks\Quark;
+
+class SimpleObject {
+  public string $property = 'Test Property';
+  public NestedObject $nestedObject;
+
+  public function __construct() {
+    $this->nestedObject = new NestedObject();
+  }
+
+  public function method(): string {
+    return 'Test Method';
+  }
+
+  public function getNested(): NestedObject {
+    return $this->nestedObject;
+  }
+}

--- a/tests/Unit/Quark/QuarkCompilerTest.php
+++ b/tests/Unit/Quark/QuarkCompilerTest.php
@@ -151,7 +151,7 @@ class QuarkCompilerTest extends QuarkTestCase {
     $method->setAccessible(true);
 
     $this->assertEquals(
-      '$test->property',
+      '$__quark->access($test, \'property\')',
       $method->invoke($this->compiler, 'test.property')
     );
   }

--- a/tests/Unit/Quark/QuarkEngineTest.php
+++ b/tests/Unit/Quark/QuarkEngineTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Quark;
 
+use Tests\Mocks\Quark\SimpleObject;
 use Tests\QuarkTestCase;
 
 class QuarkEngineTest extends QuarkTestCase {
@@ -211,6 +212,51 @@ class QuarkEngineTest extends QuarkTestCase {
     $this->assertEquals(
       '<div>test</div>',
       $this->engine->escape('<div>test</div>', 'raw')
+    );
+  }
+
+  public function testDotWithArray(): void {
+    $this->createTestTemplate('test', '<div>{{ test.title }}</div>');
+
+    $this->assertEquals(
+      '<div>Test Value</div>',
+      $this->engine->render('test', ['test' => ['title' => 'Test Value']])
+    );
+  }
+
+  public function testDotWithObject(): void {
+    $this->createTestTemplate('test', '<div>{{ test.property }}</div>');
+
+    $this->assertEquals(
+      '<div>Test Property</div>',
+      $this->engine->render('test', ['test' => new SimpleObject()])
+    );
+  }
+
+  public function testDotWithMethod(): void {
+    $this->createTestTemplate('test', '<div>{{ test.method() }}</div>');
+
+    $this->assertEquals(
+      '<div>Test Method</div>',
+      $this->engine->render('test', ['test' => new SimpleObject()])
+    );
+  }
+
+  public function testDotWithMixed(): void {
+    $this->createTestTemplate('test', '<div>{{ test.nested.method() }}</div>');
+
+    $this->assertEquals(
+      '<div>Nested Method</div>',
+      $this->engine->render('test', ['test' => new SimpleObject()])
+    );
+  }
+
+  public function testDotWithNestedMethods(): void {
+    $this->createTestTemplate('test', '<div>{{ test.getNested().method() }}</div>');
+
+    $this->assertEquals(
+      '<div>Nested Method</div>',
+      $this->engine->render('test', ['test' => new SimpleObject()])
     );
   }
 


### PR DESCRIPTION
- Improve `include` directive
- Better support dot notation in Quark expressions
  - Array values: `array.key`
  - Object properties: `object.property`
  - Method calls: `object.method()`