### PR TITLE
Quark updates

### DIFF
--- a/src/Quark/QuarkCompiler.php
+++ b/src/Quark/QuarkCompiler.php
@@ -98,7 +98,7 @@ class QuarkCompiler {
     
           $data =  "compact(" . implode(', ', $quotedVars) . ")";
         }
-        return "echo \$__quark->render('{$template}', {$data});\n";
+        return "echo \$__quark->render('{$template}', {$data}, [], true);\n";
       }
       throw new \Exception("Invalid include syntax: {$args}");
     };

--- a/src/Quark/QuarkCompiler.php
+++ b/src/Quark/QuarkCompiler.php
@@ -126,7 +126,7 @@ class QuarkCompiler {
    */
   private function tokenize(string $source): array {
     $tokens = [];
-    $pattern = '/\{\{(.*?)\}\}|\{%(.*?)%\}/s';
+    $pattern = '/\{\{(.*?)\}\}|(~[a-zA-Z\-_]+\([^~]*\))/s';
     $lastPos = 0;
 
     preg_match_all($pattern, $source, $matches, PREG_OFFSET_CAPTURE);
@@ -167,7 +167,7 @@ class QuarkCompiler {
    * @throws \Exception If the directive syntax is invalid
    */
   private function parseDirective(string $directive): array {
-    if (preg_match('/^(\w+)(?:\s+(.+))?$/', $directive, $matches)) {
+    if (preg_match('/^~(\w+)\((.*)\)$/', $directive, $matches)) {
       return [
         'type' => 'directive',
         'name' => $matches[1],

--- a/tests/Unit/Quark/QuarkCompilerTest.php
+++ b/tests/Unit/Quark/QuarkCompilerTest.php
@@ -52,7 +52,7 @@ class QuarkCompilerTest extends QuarkTestCase {
     $this->assertArrayHasKey('test', $directives);
     $this->assertEquals(
       "<?php\necho '<div>';\necho 'test_directive_ran';\necho '</div>';\n",
-      $this->compiler->compile('<div>{% test %}</div>')
+      $this->compiler->compile('<div>~test()</div>')
     );
   }
 
@@ -68,7 +68,7 @@ class QuarkCompilerTest extends QuarkTestCase {
         ['type' => 'text', 'content' => '</div>'],
         ['type' => 'directive', 'name' => 'outlet', 'args' => ''],
       ],
-      $method->invoke($this->compiler, '<div>{{ test }}</div>{% outlet %}')
+      $method->invoke($this->compiler, '<div>{{ test }}</div>~outlet()')
     );
   }
 
@@ -79,7 +79,7 @@ class QuarkCompilerTest extends QuarkTestCase {
 
     $this->assertEquals(
       ['type' => 'directive', 'name' => 'outlet', 'args' => 'custom'],
-      $method->invoke($this->compiler, 'outlet custom')
+      $method->invoke($this->compiler, '~outlet(custom)')
     );
   }
 

--- a/tests/Unit/Quark/QuarkEngineTest.php
+++ b/tests/Unit/Quark/QuarkEngineTest.php
@@ -45,8 +45,8 @@ class QuarkEngineTest extends QuarkTestCase {
   }
 
   public function testRenderTemplateWithLayout(): void {
-    $this->createTestTemplate('layout', '<div>{% outlet %}</div>');
-    $this->createTestTemplate('test', '{% layout layout %}<p>{{ test }}</p>');
+    $this->createTestTemplate('layout', '<div>~outlet()</div>');
+    $this->createTestTemplate('test', '~layout(layout)<p>{{ test }}</p>');
 
     $this->assertEquals(
       '<div><p>Test Value</p></div>',
@@ -55,7 +55,7 @@ class QuarkEngineTest extends QuarkTestCase {
   }
 
   public function testRenderTemplateWithRootLayout(): void {
-    $this->createTestTemplate('root', '<div>{% outlet %}</div>');
+    $this->createTestTemplate('root', '<div>~outlet()</div>');
     $this->createTestTemplate('test', '<p>{{ test }}</p>');
     $this->engine->setRootLayout('root');
 
@@ -66,7 +66,7 @@ class QuarkEngineTest extends QuarkTestCase {
   }
 
   public function testRenderTemplateWithSkipRootLayout(): void {
-    $this->createTestTemplate('root', '<div>{% outlet %}</div>');
+    $this->createTestTemplate('root', '<div>~outlet()</div>');
     $this->createTestTemplate('test', '<p>{{ test }}</p>');
     $this->engine->setRootLayout('root');
     $this->engine->skipRootLayout();
@@ -78,8 +78,8 @@ class QuarkEngineTest extends QuarkTestCase {
   }
 
   public function testRenderTemplateWithSkipRootDirective(): void {
-    $this->createTestTemplate('root', '<div>{% outlet %}</div>');
-    $this->createTestTemplate('test', '{% skip_root %}<p>{{ test }}</p>');
+    $this->createTestTemplate('root', '<div>~outlet()</div>');
+    $this->createTestTemplate('test', '~skip_root()<p>{{ test }}</p>');
     $this->engine->setRootLayout('root');
 
     $this->assertEquals(
@@ -89,8 +89,8 @@ class QuarkEngineTest extends QuarkTestCase {
   }
 
   public function testRenderTemplateWithCustomOutlet(): void {
-    $this->createTestTemplate('layout', '<div>{% outlet custom %}</div>');
-    $this->createTestTemplate('test', '{% layout layout %}{% slot custom %}<p>{{ test }}</p>{% endslot %}');
+    $this->createTestTemplate('layout', '<div>~outlet(custom)</div>');
+    $this->createTestTemplate('test', '~layout(layout)~slot(custom)<p>{{ test }}</p>~endslot()');
 
     $this->assertEquals(
       '<div><p>Test Value</p></div>',
@@ -99,7 +99,7 @@ class QuarkEngineTest extends QuarkTestCase {
   }
 
   public function testRenderTemplateWithInclude(): void {
-    $this->createTestTemplate('test', '<div>{% include included %}</div>');
+    $this->createTestTemplate('test', '<div>~include(included)</div>');
     $this->createTestTemplate('included', '<p>Included</p>');
 
     $this->assertEquals(
@@ -109,7 +109,7 @@ class QuarkEngineTest extends QuarkTestCase {
   }
 
   public function testRenderTemplateWithIf(): void {
-    $this->createTestTemplate('test', '<div>{% if $test %}True{% endif %}</div>');
+    $this->createTestTemplate('test', '<div>~if($test)True~endif()</div>');
 
     $this->assertEquals(
       '<div></div>',
@@ -124,7 +124,7 @@ class QuarkEngineTest extends QuarkTestCase {
   public function testRenderTemplateWithIfWithElses(): void {
     $this->createTestTemplate(
       'test',
-      '<div>{% if $test == 1 %}One{% elseif $test == 2 %}Two{% else %}None{% endif %}</div>'
+      '<div>~if($test == 1)One~elseif($test == 2)Two~else()None~endif()</div>'
     );
 
     $this->assertEquals(
@@ -144,7 +144,7 @@ class QuarkEngineTest extends QuarkTestCase {
   public function testRenderTemplateWithForeach(): void {
     $this->createTestTemplate(
       'test',
-      '<div>{% foreach $test as $item %}<p>{{ $item[\'name\'] }}</p>{% endforeach %}</div>'
+      '<div>~foreach($test as $item)<p>{{ $item[\'name\'] }}</p>~endforeach()</div>'
     );
 
     $this->assertEquals(
@@ -160,7 +160,7 @@ class QuarkEngineTest extends QuarkTestCase {
   public function testRenderTemplateWithSet(): void {
     $this->createTestTemplate(
       'test',
-      '<div>{% if $test %}{% set $text = \'new_value\' %}{% endif %}{{ text }}</div>'
+      '<div>~if($test)~set($text = \'new_value\')~endif(){{ text }}</div>'
     );
 
     $this->assertEquals(


### PR DESCRIPTION
- Fix multiple roots when using `include`
- Update the directive syntax: `~directive()`